### PR TITLE
Fix issue with CGFloat being out of scope

### DIFF
--- a/Sources/BSONSerialization/BSONSerialization.swift
+++ b/Sources/BSONSerialization/BSONSerialization.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 import SimpleStream
-
+#if !os(Linux)
+import CoreGraphics
+#endif
 
 
 public typealias BSONDoc = [String: Any?]


### PR DESCRIPTION
As is, trying to use BSONSerialization will result in an error in BSONSerialization.swift:487 :
> Cannot find type `CGFloat` in scope

This addresses that.